### PR TITLE
fix get_md5_filename name clash

### DIFF
--- a/coscmd/cos_client.py
+++ b/coscmd/cos_client.py
@@ -46,7 +46,10 @@ def getTagText(root, tag):
 
 def get_md5_filename(local_path, cos_path):
     ori_file = os.path.abspath(os.path.dirname(local_path)) + "!!!" + str(os.path.getsize(local_path)) + "!!!" + cos_path
-    return os.path.expanduser('~/.tmp/' + binascii.b2a_hex(base64.encodestring(to_printable_str(ori_file)))[0:20])
+    m = md5()
+    m.update(to_printable_str(ori_file))
+    return os.path.expanduser('~/.tmp/' + m.hexdigest())
+    #return os.path.expanduser('~/.tmp/' + binascii.b2a_hex(base64.encodestring(to_printable_str(ori_file)))[0:20])
 
 
 def query_yes_no(question, default="no"):


### PR DESCRIPTION
_path_md5 name can clash when a lot of multipart uploading is going on
md5 files can be randomly deleted by other uploading threads when their name clashes
resulting in "completing multiupload fail"

use md5 digest to reduce name clash rate