### PR TITLE
Add option to specify region at command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ coscmd -h  //查看当面版本信息
 ```
 help 信息如下所示：
 ```
-usage: coscmd [-h] [-d] [-b BUCKET] [-v]
+usage: coscmd [-h] [-d] [-b BUCKET] [-R REGION] [-v]
               {config,upload,download,delete,list,info,mget,restore,signurl,createbucket,deletebucket,putobjectacl,getobjectacl,putbucketacl,getbucketacl}
               ...
 
@@ -69,6 +69,8 @@ optional arguments:
   -d, --debug           debug mode
   -b BUCKET, --bucket BUCKET
                         set bucket
+  -R REGION, --region REGION
+                        set region
   -v, --version         show program's version number and exit
 ```
 除此之外，用户还可以在每个命令后（不加参数）输入`-h`查看该命令的具体用法，例如：

--- a/coscmd/cos_cmd.py
+++ b/coscmd/cos_cmd.py
@@ -14,6 +14,7 @@ fs_coding = sys.getfilesystemencoding()
 
 pre_appid = ""
 pre_bucket = ""
+pre_region = ""
 global res
 
 
@@ -108,11 +109,15 @@ def load_conf():
             appid = pre_appid
         if pre_bucket != "":
             bucket = pre_bucket
+        if pre_region != "":
+            region = compatible(pre_region)
+        else:
+            region = compatible(cp.get('common', 'region'))
         conf = CosConfig(
             appid=appid,
             secret_id=secret_id,
             secret_key=cp.get('common', 'secret_key'),
-            region=compatible(cp.get('common', 'region')),
+            region=region,
             bucket=bucket,
             part_size=part_size,
             max_thread=max_thread
@@ -430,6 +435,7 @@ def command_thread():
     parser = ArgumentParser(description=desc)
     parser.add_argument('-d', '--debug', help="debug mode", action="store_true", default=False)
     parser.add_argument('-b', '--bucket', help="set bucket", type=str, default="")
+    parser.add_argument('-R', '--region', help="set region", dest='region', type=str, default="")
 
     sub_parser = parser.add_subparsers()
     parser_config = sub_parser.add_parser("config", help="config your information at first.")
@@ -541,8 +547,9 @@ def command_thread():
     handler.setFormatter(logging.Formatter('%(asctime)s - [%(levelname)s]:  %(message)s'))
     logger.addHandler(handler)
     logging.getLogger('').addHandler(console)
-    global pre_appid, pre_bucket
+    global pre_appid, pre_bucket, pre_region
     pre_bucket = args.bucket
+    pre_region = args.region
     try:
         pre_appid = pre_bucket.split('-')[-1]
         pre_bucket = pre_bucket.rstrip(pre_appid)


### PR DESCRIPTION
Hi Coscmd developer(s),

We want to have the ability of specifying region at command line when we are using coscmd to move data from one bucket to another, probably in another region. So we made some changes to this command and added a new option -R (because -r has already been used for --recursive in some sub commands).

Please review this PR and it would be great if this could be merged into the official repo. Or you can make any changes to follow your code standard/policies etc.

Thanks,
Feng