### PR TITLE
添加上传文件、文件夹时自定义设置http header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ install:
     - pip install nose
     - pip install pep8
     - pip install tox
+    - pip install pyyaml
 script:
     - pep8 --max-line-length=180
     - nosetests -s

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ coscmd upload -r /home/aaa/ /  //上传到bucket根目录
 * 上传文件时需要将cos上的路径包括文件(夹)的名字补全(参考例子)。
 * COSCMD 支持大文件断点上传功能。当分片上传大文件失败时，重新上传该文件只会上传失败的分块，而不会从头开始（请保证重新上传的文件的目录以及内容和上传的目录保持一致）。
 * COSCMD 分块上传时会对每一块进行 MD5 校验。
+* 使用-H参数设置HTTP header时，请务必保证格式为json，这里是个例子：`coscmd upload -H '{"Cache-Control":"max-age=31536000","Content-Language":"zh-CN"}' <localpath> <cospath>`
 
 ### 下载文件或文件夹
 - 下载文件命令如下：

--- a/coscmd/cos_client.py
+++ b/coscmd/cos_client.py
@@ -15,6 +15,7 @@ import base64
 import datetime
 import pytz
 import urllib
+import yaml
 from tqdm import tqdm
 from wsgiref.handlers import format_date_time
 logger = logging.getLogger(__name__)
@@ -216,7 +217,7 @@ class Interface(object):
             return False
         return True
 
-    def upload_folder(self, local_path, cos_path, _type='Standard', _encryption=''):
+    def upload_folder(self, local_path, cos_path, _type='Standard', _encryption='', _http_headers=''):
 
         local_path = to_unicode(local_path)
         cos_path = to_unicode(cos_path)
@@ -232,10 +233,10 @@ class Interface(object):
         for filename in filelist:
             filepath = os.path.join(local_path, filename)
             if os.path.isdir(filepath):
-                if not self.upload_folder(filepath, cos_path+filename, _type, _encryption):
+                if not self.upload_folder(filepath, cos_path+filename, _type, _encryption, _http_headers):
                     ret_code = False
             else:
-                if self.upload_file(local_path=filepath, cos_path=cos_path+filename, _type=_type, _encryption=_encryption) is False:
+                if self.upload_file(local_path=filepath, cos_path=cos_path+filename, _type=_type, _encryption=_encryption, _http_headers=_http_headers) is False:
                     logger.info("upload {file} fail".format(file=to_printable_str(filepath)))
                     self._fail_num += 1
                     ret_code = False
@@ -244,11 +245,14 @@ class Interface(object):
                     logger.debug("upload {file} success".format(file=to_printable_str(filepath)))
         return ret_code
 
-    def upload_file(self, local_path, cos_path, _type='Standard', _encryption=''):
+    def upload_file(self, local_path, cos_path, _type='Standard', _encryption='', _http_headers=''):
+
+        _http_header = yaml.safe_load(_http_headers)
 
         def single_upload():
             self._type = _type
             self._encryption = _encryption
+
             if len(local_path) == 0:
                 data = ""
             else:
@@ -257,7 +261,7 @@ class Interface(object):
             url = self._conf.uri(path=cos_path)
             for j in range(self._retry):
                 try:
-                    http_header = dict()
+                    http_header = _http_header
                     http_header['x-cos-storage-class'] = self._type
                     if _encryption != '':
                         http_header['x-cos-server-side-encryption'] = self._encryption
@@ -296,7 +300,7 @@ class Interface(object):
                 if self.list_part(cos_path) is True:
                     logger.info("continue uploading from last breakpoint")
                     return True
-            http_header = dict()
+            http_header = _http_header
             http_header['x-cos-storage-class'] = self._type
             if _encryption != '':
                 http_header['x-cos-server-side-encryption'] = self._encryption
@@ -327,9 +331,10 @@ class Interface(object):
                     data = File.read(length)
                 url = self._conf.uri(path=cos_path)+"?partNumber={partnum}&uploadId={uploadid}".format(partnum=idx, uploadid=self._upload_id)
                 for j in range(self._retry):
+                    http_header = _http_header
                     rt = self._session.put(url=url,
                                            auth=CosS3Auth(self._conf._secret_id, self._conf._secret_key),
-                                           data=data)
+                                           data=data, headers=http_header)
                     logger.debug("multi part result: part{part}, round{round}, code: {code}, headers: {headers}, text: {text}".format(
                         part=idx,
                         round=j+1,

--- a/coscmd/cos_cmd.py
+++ b/coscmd/cos_cmd.py
@@ -154,9 +154,9 @@ class Op(object):
         args.local_path, args.cos_path = concat_path(args.local_path, args.cos_path)
         if args.recursive:
             if os.path.isfile(args.local_path) is True:
-                rt = Interface.upload_file(args.local_path, args.cos_path, args.type, args.encryption)
+                rt = Interface.upload_file(args.local_path, args.cos_path, args.type, args.encryption, args.headers)
             elif os.path.isdir(args.local_path):
-                rt = Interface.upload_folder(args.local_path, args.cos_path, args.type, args.encryption)
+                rt = Interface.upload_folder(args.local_path, args.cos_path, args.type, args.encryption, args.headers)
                 logger.info("{folders} folders, {files} files successful, {fail_files} files failed"
                             .format(folders=Interface._folder_num, files=Interface._file_num, fail_files=Interface._fail_num))
                 if rt:
@@ -172,7 +172,7 @@ class Op(object):
             if os.path.isfile(args.local_path) is False:
                 logger.warn("cannot stat '%s': No such file or directory" % to_printable_str(args.local_path))
                 return -1
-            if Interface.upload_file(args.local_path, args.cos_path, args.type, args.encryption) is True:
+            if Interface.upload_file(args.local_path, args.cos_path, args.type, args.encryption, args.headers) is True:
                 return 0
             else:
                 return -1
@@ -467,6 +467,7 @@ def command_thread():
     parser_upload.add_argument('-r', '--recursive', help="upload recursively when upload directory", action="store_true", default=False)
     parser_upload.add_argument('-t', '--type', help='specify x-cos-storage-class of files to upload', type=str, choices=['STANDARD', 'STANDARD_IA', 'NEARLINE'], default='STANDARD')
     parser_upload.add_argument('-e', '--encryption', help="set encryption", type=str, default='')
+    parser_upload.add_argument('-H', '--headers', help="set HTTP headers", type=str, default='')
     parser_upload.set_defaults(func=Op.upload)
 
     parser_download = sub_parser.add_parser("download", help="download file from COS to local.")


### PR DESCRIPTION
使用-H参数设置HTTP header时，请务必保证格式为json
这里是个例子：
```
coscmd upload -H '{"Cache-Control":"max-age=31536000","Content-Language":"zh-CN"}' <localpath> <cospath>
```

效果如图：

![http-header.png](https://i.loli.net/2018/04/06/5ac69f2e37506.png)
