### PR TITLE
fix: should exit with 0 when checking cmd version

### DIFF
--- a/coscmd/cos_cmd.py
+++ b/coscmd/cos_cmd.py
@@ -895,7 +895,11 @@ def command_thread():
 
     parser.add_argument('-v', '--version', action='version', version='%(prog)s ' + Version)
 
-    args = parser.parse_args()
+    try:
+        args = parser.parse_args()
+    except SystemExit as exc:
+        res = exc.code
+        return 0
 
     logger = logging.getLogger('coscmd')
     logger.setLevel(logging.INFO)


### PR DESCRIPTION
Related issue #189
```bash
# Before
$ python3 -m coscmd.cos_cmd -v || echo $?
cos_cmd.py 1.8.6.27
255
```

After fix: 
```bash
# env: Python 3.9.11
$ python3 -m coscmd.cos_cmd -v && echo $?
cos_cmd.py 1.8.6.27
0
```

